### PR TITLE
Fix types of import/export key for Brr_webcrypto

### DIFF
--- a/src/brr_webcrypto.ml
+++ b/src/brr_webcrypto.ml
@@ -298,7 +298,7 @@ module Subtle_crypto = struct
   (* Key encoding and decoding *)
 
   let import_key s f k a ~extractable ~usages =
-    let k = match k with | `Buffer b -> Tarray.to_jv b | `Json_web_key k -> k in
+    let k = match k with | `Buffer b -> Tarray.Buffer.to_jv b | `Json_web_key k -> k in
     Fut.of_promise ~ok:Crypto_key.of_jv @@
     Jv.call s "importKey"
       [| Jv.of_jstr f; k; Crypto_algo.to_jv a; Jv.of_bool extractable;
@@ -307,7 +307,7 @@ module Subtle_crypto = struct
   let export_key s f k =
     let ok = match Jstr.equal Crypto_key.Format.jwk f with
     | true -> fun v -> `Json_web_key v
-    | false -> fun v -> `Buffer (Tarray.of_jv v)
+    | false -> fun v -> `Buffer (Tarray.Buffer.of_jv v)
     in
     Fut.of_promise ~ok @@
     Jv.call s "exportKey" [| Jv.of_jstr f; Crypto_key.to_jv k |]

--- a/src/brr_webcrypto.mli
+++ b/src/brr_webcrypto.mli
@@ -694,14 +694,14 @@ module Subtle_crypto : sig
 
   val export_key :
     t -> Crypto_key.Format.t -> Crypto_key.t ->
-    [ `Buffer of ('a, 'b) Tarray.t | `Json_web_key of Json.t ] Fut.or_error
+    [ `Buffer of Tarray.Buffer.t | `Json_web_key of Json.t ] Fut.or_error
   (** [export_key s f k] is the key [k]
       {{:https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/exportKey}exported} in format [f]. [`Json_web_key] is only returned if
       {!Crypto_key.Format.jwk} is specified. *)
 
   val import_key :
     t -> Crypto_key.Format.t ->
-    [ `Buffer of ('a, 'b) Tarray.t | `Json_web_key of Json.t ] ->
+    [ `Buffer of Tarray.Buffer.t | `Json_web_key of Json.t ] ->
     Crypto_algo.t -> extractable:bool -> usages:Crypto_key.Usage.t list ->
     Crypto_key.t Fut.or_error
   (** [import_key s f k a ~extractable ~usage] is the key [k]


### PR DESCRIPTION
According to the documentation of [`export_key`][export_key]/[`import_key`][import_key], we should use a `Tarray.Buffer.t` instead of a `Tarray`. I added a test to check if we are able to export/import/re-export the same key and got "the same" result.

[export_key]: https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/exportKey
[import_key]: https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey