### PR TITLE
El.v: add a ?ns optional argument to specify a namespace URI

### DIFF
--- a/src/brr.ml
+++ b/src/brr.ml
@@ -998,8 +998,12 @@ module El = struct
   | true when Jstr.is_empty v -> ()
   | true -> ignore (Jv.call (Jv.get e "classList") "add" [| Jv.of_jstr v |])
 
-  let v ?(d = global_document) ?(at = []) name cs =
-    let e = Jv.call d "createElement" [| Jv.of_jstr name |] in
+  let v ?ns ?(d = global_document) ?(at = []) name cs =
+    let e =
+      match ns with
+      | None -> Jv.call d "createElement" [| Jv.of_jstr name |]
+      | Some ns -> Jv.call d "createElementNS" [| Jv.of_jstr ns; Jv.of_jstr name |]
+    in
     List.iter (set_at e) at;
     List.iter (append_child e) cs;
     e

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -1859,13 +1859,15 @@ module El : sig
   type el = t
   (** See {!t}. *)
 
-  val v : ?d:document -> ?at:At.t list -> tag_name -> t list -> t
-  (** [v ?d ?at name cs] is an element [name] with attribute [at]
+  val v : ?ns:Jstr.t -> ?d:document -> ?at:At.t list -> tag_name -> t list -> t
+  (** [v ?ns ?d ?at name cs] is an element [name] with attribute [at]
       (defaults to [[]]) and children [cs]. If [at] specifies an
-      attribute more thanonce, the last one takes over with the
+      attribute more than once, the last one takes over with the
       exception of {!At.class'} whose occurences accumulate to define
       the final value. [d] is the document on which the element is
-      defined it defaults {!Brr.G.document}. *)
+      defined, it defaults to {!Brr.G.document}. [ns] allows specifying
+      a namespace for the element; by default, the ambient namespace is used.
+  *)
 
   val txt : ?d:document -> Jstr.t -> t
   (** [txt s] is the text [s]. [d] is the document on which the element is


### PR DESCRIPTION
I've needed to use `El.v` to create SVG DOM elements, and for this to work one needs to create with them with `createElementNS`, specifying the SVG namespace URI. 
For this to be easily doable, the PR adds a `~ns` argument to `El.v` to allow specifying an explicit namespace.