### PR TITLE
Fix Brr.Blob.of_array_buffer

### DIFF
--- a/src/brr.ml
+++ b/src/brr.ml
@@ -727,7 +727,7 @@ module Blob = struct
   let of_jstr ?(init = Jv.undefined) s = Jv.new' blob [| Jv.of_jstr s; init |]
   let of_jarray ?(init = Jv.undefined) a = Jv.new' blob [| a; init |]
   let of_array_buffer ?(init = Jv.undefined) b =
-    Jv.new' blob [| Tarray.Buffer.to_jv b; init |]
+    Jv.new' blob [| Jv.of_jv_array [| Tarray.Buffer.to_jv b |]; init |]
 
   let byte_length b = Jv.Int.get b "size"
   let type' b = Jv.Jstr.get b "type"


### PR DESCRIPTION
It looks like the current implement is incorrect (and indeed failed when I tried to use it). According to the documentation, `Blob()` expects an array of ArrayBuffer(s) (https://developer.mozilla.org/en-US/docs/Web/API/Blob/Blob).