### PR TITLE
Wrap OCaml functions before passing them to JavaScript

### DIFF
--- a/src/brr.mli
+++ b/src/brr.mli
@@ -857,14 +857,15 @@ module Ev : sig
          on the event. If it does nothing will happen (except maybe
          a console warning). Defaults to [false].}} *)
 
-  val listen : ?opts:listen_opts -> 'a type' -> ('a t -> unit) -> target -> unit
+  type key
+
+  val listen : ?opts:listen_opts -> 'a type' -> ('a t -> unit) -> target -> key
   (** [listen ~opts type' f t] listens for events of type [type'] on target
       [t] with function [f] and options [opts] (see {!val:listen_opts} for
       defaults). *)
 
-  val unlisten :
-    ?opts:listen_opts -> 'a type' -> ('a t -> unit) -> target -> unit
-  (** [unlisten ~opts type' f] stops the listening introduced by the
+  val unlisten : key -> unit
+  (** [unlisten key] stops the listening introduced by the
       corresponding {!listen} invocation. *)
 
   val next : ?capture:bool -> 'a type' -> target -> 'a t Fut.t

--- a/src/jv.mli
+++ b/src/jv.mli
@@ -334,6 +334,7 @@ external apply : t -> t array -> t = "caml_js_fun_call"
 (** [apply f args] calls function [f] with arguments [args].
 '    {{!page-ffi_manual.funcs}Lookup} functions names
     in the {!Jv.global} object. *)
+external callback : int -> (_ -> _) -> t = "caml_js_wrap_callback_strict"
 
 (** {1:exns Errors and exceptions} *)
 

--- a/src/note/brr_note.ml
+++ b/src/note/brr_note.ml
@@ -57,7 +57,7 @@ module Evr = struct
     | false -> None | true -> Some (Ev.listen_opts ~capture ())
     in
     let f ev = instruct ?propagate ?default ev; f ev in
-    Ev.listen ?opts type' f t
+    ignore (Ev.listen ?opts type' f t)
 
   (* Note events *)
 
@@ -67,7 +67,7 @@ module Evr = struct
     in
     let e, send_e = E.create () in
     let f ev = instruct ?propagate ?default ev; send_e (f ev) in
-    Ev.listen ?opts type' f t;
+    ignore (Ev.listen ?opts type' f t);
     e
 
   let on_targets ?(capture = false) ?propagate ?default type' f ts =
@@ -76,7 +76,7 @@ module Evr = struct
     in
     let e, send_e = E.create () in
     let f ev = instruct ?propagate ?default ev; send_e (f (Ev.target ev) ev) in
-    List.iter (Ev.listen ?opts type' f) ts;
+    List.iter (fun t -> ignore (Ev.listen ?opts type' f t)) ts;
     e
 
   let on_el ?capture ?propagate ?default type' f el =
@@ -91,7 +91,8 @@ module Evr = struct
       instruct ?propagate ?default ev;
       send_e (f (Obj.magic (* oh well *) (Ev.target ev) : El.t) ev)
     in
-    List.iter (fun el -> Ev.listen ?opts type' f (El.as_target el)) els;
+    List.iter
+      (fun el -> ignore (Ev.listen ?opts type' f (El.as_target el))) els;
     e
 
   let unit e = ()
@@ -101,8 +102,8 @@ module Evr = struct
     | false -> None | true -> Some (Ev.listen_opts ~capture ())
     in
     let f ev = instruct ?propagate ?default ev; f ev in
-    Ev.listen ?opts type' f t;
-    fun () -> Ev.unlisten ?opts type' f t
+    let k = Ev.listen ?opts type' f t in
+    fun () -> Ev.unlisten k
 end
 
 module Elr = struct

--- a/src/note/brr_note_kit.ml
+++ b/src/note/brr_note_kit.ml
@@ -392,7 +392,8 @@ module Windowr = struct
     if Jv.is_none (Document.to_jv G.document) then S.const false else
     let is_fullscreen, set_fullscreen = S.create (in_fullscreen ()) in
     let change _e = set_fullscreen (in_fullscreen ()) in
-    Ev.listen Ev.fullscreenchange change (Document.as_target G.document);
+    ignore
+      (Ev.listen Ev.fullscreenchange change (Document.as_target G.document));
     is_fullscreen
 
   let quit =
@@ -400,7 +401,7 @@ module Windowr = struct
     if Jv.is_none (Document.to_jv G.document) then E.never else
     let quit, send_quit = E.create () in
     let send_quit _e = send_quit () in
-    Ev.listen Ev.unload send_quit (Document.as_target G.document);
+    ignore (Ev.listen Ev.unload send_quit (Document.as_target G.document));
     quit
 end
 
@@ -621,7 +622,7 @@ module Ui = struct
           El.set_prop El.Prop.value Jstr.empty input;
           El.click input
         in
-        Ev.listen Ev.click forward (El.as_target el)
+        ignore (Ev.listen Ev.click forward (El.as_target el))
       and () =
         (* input at end for not applying * + el CSS rules, this will still disturb
            last-child and el + * though *)
@@ -841,7 +842,7 @@ module Ui = struct
         (* XXX isn't there a better way tabindex (-1) doesn't work
            also this is something that should be handled in the UI framework *)
         let unset_focus _ = El.set_has_focus false el in
-        Ev.listen Ev.focus unset_focus (El.as_target el)
+        ignore (Ev.listen Ev.focus unset_focus (El.as_target el))
       in
       { el; action; enabled }
 


### PR DESCRIPTION
This is necessary to deal with the calling conventoin mismatch introduced by the upcoming effect support (ocsigen/js_of_ocaml#1340)

This partially addresses #42.

This was done rapidly, so I may have missed a few places.

I'm not sure what to do with `Brr.Ev.listen`/`Brr.Ev.unlisten` since `removeEventListener`expects to be invoked with the very same JavaScript function that was passed to `addEventListener`.  