### PR TITLE
Allow multiple classes in At.class'

### DIFF
--- a/src/brr.ml
+++ b/src/brr.ml
@@ -1145,28 +1145,31 @@ module El = struct
 
   let append_child e n = ignore (Jv.call e "appendChild" [| n |])
 
-  let rec set_atts e ss = function
+  let rec set_atts e ss clss = function
   | (a, v) :: at ->
-      if Jstr.is_empty a then set_atts e ss at else
-      if Jstr.equal a At.Name.style then set_atts e (v :: ss) at else
-      if Jstr.equal a At.Name.class' then begin
-        if not (Jstr.is_empty v)
-        then (ignore (Jv.call (Jv.get e "classList") "add" [| Jv.of_jstr v |]));
-        set_atts e ss at
-      end else begin
+      if Jstr.is_empty a then set_atts e ss clss at else
+      if Jstr.equal a At.Name.style then set_atts e (v :: ss) clss at else
+      if Jstr.equal a At.Name.class' then
+        set_atts e ss (if Jstr.is_empty v then clss else v :: clss) at
+      else begin
         ignore (Jv.call e "setAttribute" Jv.[|of_jstr a; of_jstr v|]);
-        set_atts e ss at
+        set_atts e ss clss at
       end
   | [] ->
       if ss <> [] then begin
         let a = At.Name.style in
         let v = Jstr.concat ~sep:(Jstr.v ";") (List.rev ss) in
         ignore (Jv.call e "setAttribute" Jv.[|of_jstr a; of_jstr v|]);
+      end;
+      if clss <> [] then begin
+        let a = At.Name.class' in
+        let v = Jstr.concat ~sep:(Jstr.v " ") (List.rev clss) in
+        ignore (Jv.call e "setAttribute" Jv.[|of_jstr a; of_jstr v|])
       end
 
   let v ?(d = global_document) ?(at = []) name cs =
     let e = Jv.call d "createElement" [| Jv.of_jstr name |] in
-    set_atts e [] at;
+    set_atts e [] [] at;
     List.iter (append_child e) cs;
     e
 


### PR DESCRIPTION
`At.class'` ultimately calls `HTMLElement.classList.add` which means that each call to `At.class'` can only contain one class (DOMToken).

Outside of the inconvenience (it is often the case that you want to define multiple classes at once e.g. in CSS framework), it also causes a weird discrepancy: `At.class'` is the only attribute for which Brr reject values that would be valid for the corresponding HTML attribute.

This patch uses a similar implementation for `At.class'` as the implementation for `At.style`, where the class fragments are accumulated then joined to be passed to `setAttribute` at the end of attribute processing.

This does not impact `El.class'` or `El.set_class`.

Note: I can see a line of reasoning where the choice to only allow single DOM tokens for `At.class'` is deliberate. If that is the case, feel free to disregard this PR.