### PR TITLE
Add binding for Array.isArray

### DIFF
--- a/src/jv.ml
+++ b/src/jv.ml
@@ -112,6 +112,10 @@ external to_string : t -> string = "caml_string_of_jsstring"
 
 (* Arrays *)
 
+let is_array jv =
+  Jv.call (Jv.get Jv.global "Array") "isArray" [| jv |]
+  |> Jv.to_bool
+
 module Jarray = struct
   type t = jv
   let create n = new' (get global "Array") [| of_int n |]

--- a/src/jv.mli
+++ b/src/jv.mli
@@ -305,6 +305,10 @@ external of_jstr_list : Jstr.t list ->  t = "caml_list_to_js_array"
 
 (** {2:jarr JavaScript array manipulation} *)
 
+val is_array : jv -> bool
+(** [is_array] is the
+    {{:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray}Array.isarray} function. *)
+
 (** JavaScript arrays. *)
 module Jarray : sig
 


### PR DESCRIPTION
This is useful in particular for turning json-as-javacript-values into json-as-ocaml-values.