### PR TITLE
New bindings: `inner_*`, `zoom`, `offset_*`, `scroll_into_view`, `window.parent`, `postMessage`, `ResizeObserver` and `Function`.

### DIFF
--- a/src/brr.ml
+++ b/src/brr.ml
@@ -1894,6 +1894,10 @@ module Window = struct
   let inner_width w = Jv.Int.get w "innerWidth"
   let inner_height w = Jv.Int.get w "innerHeight"
 
+  let parent w =
+    let p = Jv.get w "parent" in
+    if p == w then None else Some p
+
   (* Media properties *)
 
   let device_pixel_ratio w = Jv.Float.get w "devicePixelRatio"

--- a/src/brr.ml
+++ b/src/brr.ml
@@ -2115,3 +2115,40 @@ module G = struct
   let cancel_animation_frame fid =
     ignore @@ Jv.call Jv.global "cancelAnimationFrame" [| Jv.of_int fid|]
 end
+
+module ResizeObserver = struct
+
+  module Entry = struct
+    type t = Jv.t
+
+    let target v = Jv.get v "target"
+
+    include (Jv.Id : Jv.CONV with type t := t)
+  end
+
+  type observer = Jv.t
+
+  let create : (Entry.t list -> observer -> unit) -> observer =
+    fun callback ->
+    let callback e o =
+      let e = Jv.to_list Entry.of_jv e in
+      callback e o
+    in
+    let callback = Jv.callback ~arity:2 callback in
+    let constructor = Jv.get Jv.global "ResizeObserver" in
+    Jv.new' constructor [| callback |]
+
+  let observe : observer -> El.t -> unit =
+    fun observer target ->
+    ignore @@ Jv.call observer "observe" [| target |]
+
+  let unobserve : observer -> El.t -> unit =
+    fun observer target ->
+    ignore @@ Jv.call observer "unobserve" [| target |]
+
+  let disconnect : observer -> unit =
+    fun observer ->
+    ignore @@ Jv.call observer "disconnect" [| |]
+
+  include (Jv.Id : Jv.CONV with type t := observer)
+end

--- a/src/brr.ml
+++ b/src/brr.ml
@@ -1427,9 +1427,23 @@ module El = struct
   let scroll_w e = Jv.Float.get e "scrollWidth"
   let scroll_h e = Jv.Float.get e "scrollHeight"
 
-  let scroll_into_view ?(align_v = `Start) e =
-    let align = match align_v with `Start -> true | `End -> false in
-    ignore @@ Jv.call e "scrollIntoView" [| Jv.of_bool align |]
+  let scroll_into_view ?(align_v = `Start) ?behavior e =
+    let align = match align_v with
+      | `Start -> "start"
+      | `Center -> "center"
+      | `Nearest -> "nearest"
+      | `End -> "end"
+    in
+    let behavior =
+      Jv.of_option ~none:Jv.null Jv.of_string @@
+        Option.map (function
+            | `Smooth -> "smooth"
+            | `Instant -> "instant"
+            | `Auto -> "auto")
+          behavior
+    in
+    let options = Jv.obj [|"block", Jv.of_string align; "behavior" , behavior |] in
+    ignore @@ Jv.call e "scrollIntoView" [| options |]
 
   (* Focus *)
 

--- a/src/brr.ml
+++ b/src/brr.ml
@@ -1363,6 +1363,7 @@ module El = struct
     let visibility = Jstr.v "visibility"
     let width = Jstr.v "width"
     let z_index = Jstr.v "z-index"
+    let zoom = Jstr.v "zoom"
   end
 
   let computed_style ?(w = Jv.get Jv.global "window") p e =

--- a/src/brr.ml
+++ b/src/brr.ml
@@ -1870,6 +1870,9 @@ module Window = struct
   let scroll_x w = Jv.Float.get w "scrollX"
   let scroll_y w = Jv.Float.get w "scrollY"
 
+  let inner_width w = Jv.Int.get w "innerWidth"
+  let inner_height w = Jv.Int.get w "innerHeight"
+
   (* Media properties *)
 
   let device_pixel_ratio w = Jv.Float.get w "devicePixelRatio"

--- a/src/brr.ml
+++ b/src/brr.ml
@@ -1221,8 +1221,18 @@ module El = struct
         ignore (Jv.call e "setAttribute" Jv.[|of_jstr a; of_jstr v|])
       end
 
-  let v ?(d = global_document) ?(at = []) name cs =
-    let e = Jv.call d "createElement" [| Jv.of_jstr name |] in
+  let v ?ns ?(d = global_document) ?(at = []) name cs =
+    let e =
+      match ns with
+      | None -> Jv.call d "createElement" [| Jv.of_jstr name |]
+      | Some ns ->
+         let ns = match ns with
+           | `HTML -> "http://www.w3.org/1999/xhtml"
+           | `SVG -> "http://www.w3.org/2000/svg"
+           | `MathML -> "http://www.w3.org/1998/Math/MathML"
+         in
+         Jv.call d "createElementNS" [| Jv.of_string ns ; Jv.of_jstr name |]
+    in
     set_atts e [] [] at;
     List.iter (append_child e) cs;
     e

--- a/src/brr.ml
+++ b/src/brr.ml
@@ -1400,6 +1400,16 @@ module El = struct
   let bound_w e = Jv.Float.get (Jv.call e "getBoundingClientRect" [||]) "width"
   let bound_h e = Jv.Float.get (Jv.call e "getBoundingClientRect" [||]) "height"
 
+  (* Offset *)
+
+  let offset_w e = Jv.Int.get e "offsetWidth"
+  let offset_h e = Jv.Int.get e "offsetHeight"
+
+  let offset_left e = Jv.Int.get e "offsetLeft"
+  let offset_top e = Jv.Int.get e "offsetTop"
+
+  let offset_parent e = Jv.get e "offsetParent" |> Jv.to_option of_jv
+
   (* Scrolling *)
 
   let scroll_x e = Jv.Float.get e "scrollLeft"

--- a/src/brr.ml
+++ b/src/brr.ml
@@ -1898,6 +1898,9 @@ module Window = struct
     let p = Jv.get w "parent" in
     if p == w then None else Some p
 
+  let post_message w ~msg =
+    ignore @@ Jv.call w "postMessage" [| msg |]
+
   (* Media properties *)
 
   let device_pixel_ratio w = Jv.Float.get w "devicePixelRatio"

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -3390,7 +3390,7 @@ module Window : sig
       {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/open}
       loads the specified resource} [url] into a new or existing browsing
       context with the specified [name] and
-      {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/open#window_features}
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/open#windowfeatures}
       window features}. [None] is returned if the window could not be
       opened.*)
 

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -2062,7 +2062,7 @@ module El : sig
   type el = t
   (** See {!t}. *)
 
-  val v : ?d:document -> ?at:At.t list -> tag_name -> t list -> t
+  val v : ?ns:[`HTML | `SVG | `MathML] -> ?d:document -> ?at:At.t list -> tag_name -> t list -> t
   (** [v ?d ?at name cs] is an element [name] with attribute [at]
       (defaults to [[]]) and children [cs]. If [at] specifies an
       attribute more than once, the last one takes over with the

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -2311,6 +2311,14 @@ module El : sig
   val bound_h : t -> float
   (** [bound_h e] is [e]'s bound height. *)
 
+  (** {1 Offset} *)
+
+  val offset_h : t -> int
+  val offset_w : t -> int
+  val offset_top : t -> int
+  val offset_left : t -> int
+  val offset_parent : t -> t option
+
   (** {1:scrolling Scrolling} *)
 
   val scroll_x : t -> float

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -3837,3 +3837,30 @@ module G : sig
   (** [cancel_animation_frame fid]
       {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/cancelAnimationFrame}cancels} the animation frame request [a]. *)
 end
+
+module ResizeObserver : sig
+
+  module Entry : sig
+    type t
+
+    val target : t -> El.t
+
+    (**/**)
+    include Jv.CONV with type t := t
+    (**/**)
+  end
+
+  type observer
+
+  val create : (Entry.t list -> observer -> unit) -> observer
+
+  val observe : observer -> El.t -> unit
+
+  val unobserve : observer -> El.t -> unit
+
+  val disconnect : observer -> unit
+
+  (**/**)
+  include Jv.CONV with type t := observer
+  (**/**)
+end

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -3359,6 +3359,14 @@ module Window : sig
       height} of the window in pixels, including the height of the horizontal
       scroll bar, if present. *)
 
+  val parent : t -> t option
+  (** [parent w] is the
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/parent}parent}
+      of the window, if it has one.
+
+      When a window is loaded in an [<iframe>], [<object>], or [<frame>], its
+      parent is the window with the element embedding the window. *)
+
   (** {1:media Media properties} *)
 
   val device_pixel_ratio : t -> float

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -2264,7 +2264,7 @@ module El : sig
       [e] to [v] with priority [important] (defaults to [false]). *)
 
   val remove_inline_style : Style.prop -> t -> unit
-  (** [remove_inline_style p e] removes the inlie style property [p]
+  (** [remove_inline_style p e] removes the inline style property [p]
       of [e]. *)
 
   (** {1:layout Layout} *)

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -3338,6 +3338,18 @@ module Window : sig
       {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY}
       vertically scrolled} by. *)
 
+  val inner_width : t -> int
+  (** [inner_width w] is the
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth}interior
+      height} of the window in pixels, including the width of the vertical
+      scroll bar, if present. *)
+
+  val inner_height : t -> int
+  (** [inner_height w] is the
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/innerHeight}interior
+      height} of the window in pixels, including the height of the horizontal
+      scroll bar, if present. *)
+
   (** {1:media Media properties} *)
 
   val device_pixel_ratio : t -> float

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -2335,12 +2335,30 @@ module El : sig
   (** [scroll_h e] is the minimum height the element would require
       to display without a vertical scrollbar. *)
 
-  val scroll_into_view : ?align_v:[ `Start | `End ] -> t -> unit
-  (** [scroll_into_view ~align e]
-      {{:https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView}scrolls} [e] into view. If [align_v] is [`Start] (default) the top of the
-      element is align with to to the top of the scrollable area. If
-      [align_v] is [`End] the bottom of the element is aligned with the
-      bottom of the scrollable area. *)
+  val scroll_into_view :
+    ?align_v:[ `Center | `End | `Nearest | `Start ] ->
+    ?behavior:[< `Auto | `Instant | `Smooth ] ->
+    t ->
+    unit
+  (** [scroll_into_view ~align_v ~behavior e]
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView}scrolls}
+      [e] into view.
+
+      [align_v] controls the
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#block}block}
+      option:
+      - with [`Start] (default) the top of the element is align with to to the
+        top of the scrollable area.
+      - with [`End] the bottom of the element is
+        aligned with the bottom of the scrollable area.
+
+      [behavior] controls the
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#behavior}behavior}
+      option:
+      - with [`Auto] (default) scroll behavior is determined by the computed value of [scroll-behavior].
+      - with [`Smooth] scrolling should animate smoothly.
+      - with [`Instant] scrolling should happen instantly in a single jump.
+  *)
 
   (** {1:focus Focus} *)
 

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -3367,6 +3367,11 @@ module Window : sig
       When a window is loaded in an [<iframe>], [<object>], or [<frame>], its
       parent is the window with the element embedding the window. *)
 
+  val post_message : t -> msg:Jv.t -> unit
+  (** [post_message w ~msg]
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage}dispatches}
+      a {{!Brr_io.Message.Ev}Message events} on [w]. *)
+
   (** {1:media Media properties} *)
 
   val device_pixel_ratio : t -> float

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -2249,6 +2249,7 @@ module El : sig
     val visibility : prop
     val width : prop
     val z_index : prop
+    val zoom : prop
   end
 
   val computed_style : ?w:window -> Style.prop -> t -> Jstr.t

--- a/src/jv.mli
+++ b/src/jv.mli
@@ -373,6 +373,24 @@ external callback : arity:int -> (_ -> _) -> t = "caml_js_wrap_callback_strict"
 (** [callback ~arity f] makes function [f] with arity [arity] callable
     from JavaScript. *)
 
+module Function : sig
+  type _ args =
+    | [] : jv args
+    | (::) : (string * ('a -> jv)) * 'b args -> ('a -> 'b) args
+
+  val v : args:('a args) -> body:Jstr.t -> 'a
+  (** Creates a function with the given body. For instance:
+
+      {[
+        let body = Jstr.v "console.log(x, y + 2) ; return x" in
+        let args = Function.[("x", of_string) ; ("y", of_int)] in
+        let f = Function.v ~body ~args in
+        f "Hello" 42
+      ]}
+  *)
+
+end
+
 (** {1:exns Errors and exceptions} *)
 
 (** Error objects. *)


### PR DESCRIPTION
This PR has a batch of bindings. Happy to remove any of them if you tell me so!

- Support for namespacing when creating elements. I saw #17 and #54 but unfortunately `brr_svg` never got release :'(
  Nevertheless, it might be better to remove this change from the PR and try to ask @schutm whether they would be willing to upstream or publish their library on opam!

- Addition of the `zoom` style property in `Brr.El.Style`

- Binding to the `offset_{height ; width ; top ; left ; parent }` function.

- Add more options to `scroll_into_view` (auto, instant or smooth scrolling, as well as nearest and centered scrolling)

- Bindings to `inner_width` and `inner_height`

- Bindings to `window.parent`

- Bindings to `window.postMessage`

- Bindings to the `ResizeObserver` module

- Bindings to `Function`

Also includes fixes of small typos!