### PR TITLE
Add (minimal) bindings to `resizeObserver`

### DIFF
--- a/src/brr.ml
+++ b/src/brr.ml
@@ -2112,3 +2112,40 @@ module G = struct
   let cancel_animation_frame fid =
     ignore @@ Jv.call Jv.global "cancelAnimationFrame" [| Jv.of_int fid|]
 end
+
+module ResizeObserver = struct
+
+  module Entry = struct
+    type t = Jv.t
+
+    let target v = Jv.get v "target"
+
+    include (Jv.Id : Jv.CONV with type t := t)
+  end
+
+  type observer = Jv.t
+
+  let create : (Entry.t list -> observer -> unit) -> observer =
+    fun callback ->
+    let callback e o =
+      let e = Jv.to_list Entry.of_jv e in
+      callback e o
+    in
+    let callback = Jv.callback ~arity:2 callback in
+    let constructor = Jv.get Jv.global "ResizeObserver" in
+    Jv.new' constructor [| callback |]
+
+  let observe : observer -> El.t -> unit =
+    fun observer target ->
+    ignore @@ Jv.call observer "observe" [| target |]
+
+  let unobserve : observer -> El.t -> unit =
+    fun observer target ->
+    ignore @@ Jv.call observer "unobserve" [| target |]
+
+  let disconnect : observer -> unit =
+    fun observer ->
+    ignore @@ Jv.call observer "disconnect" [| |]
+
+  include (Jv.Id : Jv.CONV with type t := observer)
+end

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -3826,28 +3826,54 @@ module G : sig
       {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/cancelAnimationFrame}cancels} the animation frame request [a]. *)
 end
 
+(** [ResizeObserver] objects.
+
+    See the {{:https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver}
+    ResizeObserver API}. *)
 module ResizeObserver : sig
 
+  (** [ResizeObserverEntry] objects.
+
+      See the {{:https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry}
+      ResizeObserverEntry API}. *)
   module Entry : sig
     type t
-
+    (** Type for
+        {{:https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry}observed
+        entries} as passed to the observer's callback *)
+    
     val target : t -> El.t
+    (** [target entry] is the element
+        {{:https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/target}associated
+        to [entry]}.*)
 
     (**/**)
     include Jv.CONV with type t := t
     (**/**)
   end
 
-  type observer
+  type t
+  (** The type for resize observers. *)
 
-  val create : (Entry.t list -> observer -> unit) -> observer
+  val create : (Entry.t list -> t -> unit) ->  t
+  (** [create callback] is resize observer of type [t]. It will call [callback]
+      on all observed entries, whenever one of them change size.
 
-  val observe : observer -> El.t -> unit
+      See
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/ResizeObserver}the
+      doc}.*)
 
-  val unobserve : observer -> El.t -> unit
+  val observe : t -> El.t -> unit
+  (** [observe observer entry] makes [observer] start observing [entry], as explained
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe}here}. *)
 
-  val disconnect : observer -> unit
+  val unobserve : t -> El.t -> unit
+  (** [unobserve observer entry] ends [observer]'s observation of [entry], as explained
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/unobserve}here}. *)
 
+  val disconnect : t -> unit
+  (** [disconnect observer] unobserves all observed entries, as explained
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/disconnect}here}. *)
   (**/**)
   include Jv.CONV with type t := observer
   (**/**)

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -3825,3 +3825,30 @@ module G : sig
   (** [cancel_animation_frame fid]
       {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/cancelAnimationFrame}cancels} the animation frame request [a]. *)
 end
+
+module ResizeObserver : sig
+
+  module Entry : sig
+    type t
+
+    val target : t -> El.t
+
+    (**/**)
+    include Jv.CONV with type t := t
+    (**/**)
+  end
+
+  type observer
+
+  val create : (Entry.t list -> observer -> unit) -> observer
+
+  val observe : observer -> El.t -> unit
+
+  val unobserve : observer -> El.t -> unit
+
+  val disconnect : observer -> unit
+
+  (**/**)
+  include Jv.CONV with type t := observer
+  (**/**)
+end


### PR DESCRIPTION
This adds bindings to the [ResizeObserver API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver).
For now, only `target` can be extracted from [entries](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry), but that is a first step.