### PR TITLE
Add `Window.parent` support

### DIFF
--- a/src/brr.ml
+++ b/src/brr.ml
@@ -1870,6 +1870,9 @@ module Window = struct
   let scroll_x w = Jv.Float.get w "scrollX"
   let scroll_y w = Jv.Float.get w "scrollY"
 
+  let parent w =
+    let p = Jv.get w "parent" in
+    if p == w then None else Some p
   (* Media properties *)
 
   let device_pixel_ratio w = Jv.Float.get w "devicePixelRatio"

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -3338,6 +3338,15 @@ module Window : sig
       {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY}
       vertically scrolled} by. *)
 
+
+  val parent : t -> t option
+  (** [parent w] is the
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/parent}parent}
+      of the window, if it has one.
+
+      When a window is loaded in an [<iframe>], [<object>], or [<frame>], its
+      parent is the window with the element embedding the window. *)
+
   (** {1:media Media properties} *)
 
   val device_pixel_ratio : t -> float


### PR DESCRIPTION
Add support for `Window`'s [parent](https://developer.mozilla.org/en-US/docs/Web/API/Window/parent) property.