### PR TITLE
Add `zoom` predefined style property name

### DIFF
--- a/src/brr.ml
+++ b/src/brr.ml
@@ -1363,6 +1363,7 @@ module El = struct
     let visibility = Jstr.v "visibility"
     let width = Jstr.v "width"
     let z_index = Jstr.v "z-index"
+    let zoom = Jstr.v "zoom"
   end
 
   let computed_style ?(w = Jv.get Jv.global "window") p e =

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -2249,6 +2249,7 @@ module El : sig
     val visibility : prop
     val width : prop
     val z_index : prop
+    val zoom : prop
   end
 
   val computed_style : ?w:window -> Style.prop -> t -> Jstr.t


### PR DESCRIPTION
Adds the predefined css style [zoom](https://developer.mozilla.org/en-US/docs/Web/CSS/zoom).

(It is really satisfying to get autocompletion on css property names, so I think slowly filling these predefined names is improvement)