### PR TITLE
Add bindings to `Window`'s inner sizes

### DIFF
--- a/src/brr.ml
+++ b/src/brr.ml
@@ -1870,6 +1870,9 @@ module Window = struct
   let scroll_x w = Jv.Float.get w "scrollX"
   let scroll_y w = Jv.Float.get w "scrollY"
 
+  let inner_width w = Jv.Int.get w "innerWidth"
+  let inner_height w = Jv.Int.get w "innerHeight"
+
   (* Media properties *)
 
   let device_pixel_ratio w = Jv.Float.get w "devicePixelRatio"

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -3338,6 +3338,18 @@ module Window : sig
       {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY}
       vertically scrolled} by. *)
 
+  val inner_width : t -> int
+  (** [inner_width w] is the
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth}interior
+      height} of the window in pixels, including the width of the vertical
+      scroll bar, if present. *)
+
+  val inner_height : t -> int
+  (** [inner_height w] is the
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/Window/innerHeight}interior
+      height} of the window in pixels, including the height of the horizontal
+      scroll bar, if present. *)
+
   (** {1:media Media properties} *)
 
   val device_pixel_ratio : t -> float


### PR DESCRIPTION
Adds bindings to [inner_width](https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth) and [inner_height](https://developer.mozilla.org/en-US/docs/Web/API/Window/innerHeight).