### PR TITLE
Bindings to offset parent, dimensions and coordinates  

### DIFF
--- a/src/brr.ml
+++ b/src/brr.ml
@@ -1399,6 +1399,16 @@ module El = struct
   let bound_w e = Jv.Float.get (Jv.call e "getBoundingClientRect" [||]) "width"
   let bound_h e = Jv.Float.get (Jv.call e "getBoundingClientRect" [||]) "height"
 
+  (* Offset *)
+
+  let offset_w e = Jv.Int.get e "offsetWidth"
+  let offset_h e = Jv.Int.get e "offsetHeight"
+
+  let offset_left e = Jv.Int.get e "offsetLeft"
+  let offset_top e = Jv.Int.get e "offsetTop"
+
+  let offset_parent e = Jv.get e "offsetParent" |> Jv.to_option of_jv
+
   (* Scrolling *)
 
   let scroll_x e = Jv.Float.get e "scrollLeft"

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -2310,6 +2310,14 @@ module El : sig
   val bound_h : t -> float
   (** [bound_h e] is [e]'s bound height. *)
 
+  (** {1 Offset} *)
+
+  val offset_h : t -> int
+  val offset_w : t -> int
+  val offset_top : t -> int
+  val offset_left : t -> int
+  val offset_parent : t -> t option
+
   (** {1:scrolling Scrolling} *)
 
   val scroll_x : t -> float

--- a/src/brr.mli
+++ b/src/brr.mli
@@ -2313,10 +2313,48 @@ module El : sig
   (** {1 Offset} *)
 
   val offset_h : t -> int
+  (** [offset_w e] is the height of [e] in CSS pixels, excluding borders,
+      padding, scrollbars and pseudo-elements, and ignoring transforms.
+
+      See the
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight}MDN
+      doc} and the
+      {{:https://www.w3.org/TR/cssom-view-1/#dom-htmlelement-offsetheight}specification}
+      for a precise description. *)
+
   val offset_w : t -> int
+  (** [offset_w e] is the width of [e] in CSS pixels, excluding borders,
+      padding, scrollbars and pseudo-elements, and ignoring transforms.
+
+      See the
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth}MDN
+      doc} and the
+      {{:https://www.w3.org/TR/cssom-view-1/#dom-htmlelement-offsetwidth}specification}
+      for a precise description. *)
+
   val offset_top : t -> int
+  (** [offset_top e] is the number of CSS pixels that the upper left corner of
+      the current element is offset to the left within the
+      {{!offset_parent}parent node}. See the
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetTop}MDN
+      doc} and the
+      {{:https://www.w3.org/TR/cssom-view-1/#dom-htmlelement-offsettop}specification}
+      for a precise description. *)
+
   val offset_left : t -> int
+  (** [offset_left e] is the number of CSS pixels that the upper left corner of
+      the current element is offset to the left within the
+      {{!offset_parent}parent node}. See the
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetLeft}MDN
+      doc} and the
+      {{:https://www.w3.org/TR/cssom-view-1/#dom-htmlelement-offsetleft}specification}
+      for a precise description. *)
+
   val offset_parent : t -> t option
+  (** [offset_parent e] is the element (if it exists) which is the closest
+      (nearest in the containment hierarchy)
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent}positioned
+      ancestor element}. *)
 
   (** {1:scrolling Scrolling} *)
 


### PR DESCRIPTION
Add bindings to `offsetParent`, `offsetWidth` and `offsetHeight`, and `offsetTop` and `offsetLeft`.

I tried to add the relevant info in the doc but defining what this actually is in few words is not so simple, so I left the specs links.