### PR TITLE
Fix variable shadowing Canvas.attrs

### DIFF
--- a/B0.ml
+++ b/B0.ml
@@ -93,7 +93,7 @@ let base_css = `File ~/"test/base.css"
 let test ?(meta = B0_meta.empty) ?doc ?(requires = []) ?(srcs = []) src =
   let srcs = `File src :: base_css :: srcs in
   let requires = brr :: requires in
-  let name = Fpath.basename ~strip_ext:true src in
+  let name = Fpath.basename ~strip_exts:true src in
   let meta =
     meta |> B0_meta.(tag test) |> ~~ B0_jsoo.compile_opts Cmd.(arg "--pretty")
   in

--- a/src/brr_canvas.ml
+++ b/src/brr_canvas.ml
@@ -286,7 +286,7 @@ module C2d = struct
 
   type attrs = Jv.t
 
-  let attrs ?alpha ?color_space ?desynchronized ?will_read_frequently () =
+  let create_attrs ?alpha ?color_space ?desynchronized ?will_read_frequently () =
     let o = Jv.obj [||] in
     Jv.Bool.set_if_some o "alpha" alpha;
     Jv.Jstr.set_if_some o "colorSpace" color_space;

--- a/src/brr_canvas.mli
+++ b/src/brr_canvas.mli
@@ -395,9 +395,9 @@ module C2d : sig
   type attrs
   (** The type for {{:https://html.spec.whatwg.org/multipage/canvas.html#canvasrenderingcontext2dsettings}CanvasRenderingContext2DSettings}. *)
 
-  val attrs :
+  val create_attrs :
     ?alpha:bool -> ?color_space:Jstr.t -> ?desynchronized:bool -> unit -> attrs
-  (** [attrs ()] are {!type-attrs} with the given attributes. *)
+  (** [create_attrs ()] are {!type-attrs} with the given attributes. *)
 
   val attrs_alpha : attrs -> bool
   (** [attrs_alpha a] is the [alpha] attribute of [a]. *)

--- a/src/brr_canvas.mli
+++ b/src/brr_canvas.mli
@@ -396,7 +396,7 @@ module C2d : sig
   (** The type for {{:https://html.spec.whatwg.org/multipage/canvas.html#canvasrenderingcontext2dsettings}CanvasRenderingContext2DSettings}. *)
 
   val create_attrs :
-    ?alpha:bool -> ?color_space:Jstr.t -> ?desynchronized:bool -> unit -> attrs
+    ?alpha:bool -> ?color_space:Jstr.t -> ?desynchronized:bool -> ?will_read_frequently:bool -> unit -> attrs
   (** [create_attrs ()] are {!type-attrs} with the given attributes. *)
 
   val attrs_alpha : attrs -> bool


### PR DESCRIPTION
Not sure if this is a proper fix. 

I was playing around with Canvas and wanted to add options to the canvas creation. But it seems that the `attrs` creation is shadowed by the `attrs` getter on the `C2d` module.

PS. I was not able to run the build or test. Is there a Contributing guide that i missed ?